### PR TITLE
[bug] append output to prompt adds newline

### DIFF
--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -149,22 +149,28 @@ const Explorer = ({
       switch (mode) {
         case DEVELOP_MODE: {
           if (e.keyCode == KEY_ENTER && e.shiftKey) {
+            e.preventDefault();
             makeCompletionRequest();
           }
 
           if (e.keyCode == KEY_ENTER && e.ctrlKey) {
+            e.preventDefault();
             appendToPrompt();
           }
 
           if (e.keyCode == KEY_N && e.ctrlKey) {
+            e.preventDefault();
             setAnnotateOpen(true);
           }
 
           if (e.keyCode == KEY_I) {
-            const focused = filter(inputRefs, (ref) => {
+            const inputFocused = filter(inputRefs, (ref) => {
               return ref.current?.inputRef?.current?.matches(":focus");
             });
-            if (!focused.length) {
+
+            const anyFocused = inputFocused.length || promptRef?.current?.matches(":focus");
+            if (!anyFocused) {
+              e.preventDefault();
               promptRef?.current?.focus();
             }
           }
@@ -173,6 +179,7 @@ const Explorer = ({
         }
         case ANNOTATION_MODE: {
           if (e.keyCode == KEY_ENTER && e.shiftKey) {
+            e.preventDefault();
             handleSaveNote();
           }
         }


### PR DESCRIPTION
# In this PR

Bug reported - https://openai-api.slack.com/archives/C01763GPGTC/p1596804524209400?thread_ts=1596216349.338600&cid=C01763GPGTC
> Submit and append output add extra line to the prompt when using shortcuts

- `.preventDefault` when keyboard shortcuts are triggered so they don't add characters to input