### PR TITLE
Add share button to output section

### DIFF
--- a/lib/db.ts
+++ b/lib/db.ts
@@ -41,4 +41,17 @@ export interface SharedCompletionRequest {
   annotations?: Annotations;
 }
 
+export const shareCompletionRequest = async (id: string, data: SharedCompletionRequest) => {
+  const saveShareRes = await db
+    .collection(SHARED_COMPLETION_REQUESTS)
+    .add(data);
+
+  await db
+    .collection(COMPLETION_REQUESTS)
+    .doc(id)
+    .set({ sharedId: saveShareRes.id }, { merge: true });
+
+  return saveShareRes.id;
+}
+
 export default db;

--- a/lib/hooks/index.ts
+++ b/lib/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from "./layout";
 export * from "./storage";
+export * from "./timeout";

--- a/lib/hooks/timeout.ts
+++ b/lib/hooks/timeout.ts
@@ -1,0 +1,15 @@
+import { useState } from "react";
+
+export function useStateTimeout<T>(
+  revertVal: T,
+  seconds: number
+): [T, (arg: T) => void] {
+  const [val, setVal] = useState<T>(revertVal);
+
+  const setRevertTimeout = (newVal: T) => {
+    setVal(newVal);
+    setTimeout(() => setVal(revertVal), seconds);
+  }
+
+  return [val, setRevertTimeout];
+}


### PR DESCRIPTION
# In this PR
- Make it easy to share directly from output panel after a completion (before needed to open up history drawer)
- Add a button
- Update database state if not already shared
- Copy link to clipboard