### PR TITLE
Show text provenance in prompt field

### DIFF
--- a/components/Draft.css
+++ b/components/Draft.css
@@ -1,0 +1,228 @@
+/**
+ * Draft v0.11.6
+ *
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+.DraftEditor-editorContainer,
+.DraftEditor-root,
+.public-DraftEditor-content {
+  height: inherit;
+  text-align: initial;
+}
+
+.public-DraftEditor-content[contenteditable="true"] {
+  -webkit-user-modify: read-write-plaintext-only;
+}
+
+.DraftEditor-root {
+  min-height: 200px;
+  position: relative;
+  border-radius: 5px;
+  border: 2px solid #f0f4f8;
+  padding: 20px;
+  line-height: 1.5em;
+}
+
+.DraftEditor-editorContainer {
+  background-color: rgba(255, 255, 255, 0);
+  border-left: 0.1px solid transparent;
+  position: relative;
+  z-index: 1;
+}
+
+.public-DraftEditor-block {
+  position: relative;
+}
+
+.DraftEditor-alignLeft .public-DraftStyleDefault-block {
+  text-align: left;
+}
+
+.DraftEditor-alignLeft .public-DraftEditorPlaceholder-root {
+  left: 0;
+  text-align: left;
+}
+
+.DraftEditor-alignCenter .public-DraftStyleDefault-block {
+  text-align: center;
+}
+
+.DraftEditor-alignCenter .public-DraftEditorPlaceholder-root {
+  margin: 0 auto;
+  text-align: center;
+  width: 100%;
+}
+
+.DraftEditor-alignRight .public-DraftStyleDefault-block {
+  text-align: right;
+}
+
+.DraftEditor-alignRight .public-DraftEditorPlaceholder-root {
+  right: 0;
+  text-align: right;
+}
+
+.public-DraftEditorPlaceholder-root {
+  color: #9197a3;
+  position: absolute;
+  width: 100%;
+  z-index: 1;
+}
+
+.public-DraftEditorPlaceholder-hasFocus {
+  color: #bdc1c9;
+}
+
+.DraftEditorPlaceholder-hidden {
+  display: none;
+}
+
+.public-DraftStyleDefault-block {
+  position: relative;
+  white-space: pre-wrap;
+}
+
+.public-DraftStyleDefault-ltr {
+  direction: ltr;
+  text-align: left;
+}
+
+.public-DraftStyleDefault-rtl {
+  direction: rtl;
+  text-align: right;
+}
+
+.public-DraftStyleDefault-listLTR {
+  direction: ltr;
+}
+
+.public-DraftStyleDefault-listRTL {
+  direction: rtl;
+}
+
+.public-DraftStyleDefault-ol,
+.public-DraftStyleDefault-ul {
+  margin: 16px 0;
+  padding: 0;
+}
+
+.public-DraftStyleDefault-depth0.public-DraftStyleDefault-listLTR {
+  margin-left: 1.5em;
+}
+
+.public-DraftStyleDefault-depth0.public-DraftStyleDefault-listRTL {
+  margin-right: 1.5em;
+}
+
+.public-DraftStyleDefault-depth1.public-DraftStyleDefault-listLTR {
+  margin-left: 3em;
+}
+
+.public-DraftStyleDefault-depth1.public-DraftStyleDefault-listRTL {
+  margin-right: 3em;
+}
+
+.public-DraftStyleDefault-depth2.public-DraftStyleDefault-listLTR {
+  margin-left: 4.5em;
+}
+
+.public-DraftStyleDefault-depth2.public-DraftStyleDefault-listRTL {
+  margin-right: 4.5em;
+}
+
+.public-DraftStyleDefault-depth3.public-DraftStyleDefault-listLTR {
+  margin-left: 6em;
+}
+
+.public-DraftStyleDefault-depth3.public-DraftStyleDefault-listRTL {
+  margin-right: 6em;
+}
+
+.public-DraftStyleDefault-depth4.public-DraftStyleDefault-listLTR {
+  margin-left: 7.5em;
+}
+
+.public-DraftStyleDefault-depth4.public-DraftStyleDefault-listRTL {
+  margin-right: 7.5em;
+}
+
+.public-DraftStyleDefault-unorderedListItem {
+  list-style-type: square;
+  position: relative;
+}
+
+.public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth0 {
+  list-style-type: disc;
+}
+
+.public-DraftStyleDefault-unorderedListItem.public-DraftStyleDefault-depth1 {
+  list-style-type: circle;
+}
+
+.public-DraftStyleDefault-orderedListItem {
+  list-style-type: none;
+  position: relative;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-listLTR:before {
+  left: -36px;
+  position: absolute;
+  text-align: right;
+  width: 30px;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-listRTL:before {
+  position: absolute;
+  right: -36px;
+  text-align: left;
+  width: 30px;
+}
+
+.public-DraftStyleDefault-orderedListItem:before {
+  content: counter(ol0) ". ";
+  counter-increment: ol0;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth1:before {
+  content: counter(ol1, lower-alpha) ". ";
+  counter-increment: ol1;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth2:before {
+  content: counter(ol2, lower-roman) ". ";
+  counter-increment: ol2;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth3:before {
+  content: counter(ol3) ". ";
+  counter-increment: ol3;
+}
+
+.public-DraftStyleDefault-orderedListItem.public-DraftStyleDefault-depth4:before {
+  content: counter(ol4, lower-alpha) ". ";
+  counter-increment: ol4;
+}
+
+.public-DraftStyleDefault-depth0.public-DraftStyleDefault-reset {
+  counter-reset: ol0;
+}
+
+.public-DraftStyleDefault-depth1.public-DraftStyleDefault-reset {
+  counter-reset: ol1;
+}
+
+.public-DraftStyleDefault-depth2.public-DraftStyleDefault-reset {
+  counter-reset: ol2;
+}
+
+.public-DraftStyleDefault-depth3.public-DraftStyleDefault-reset {
+  counter-reset: ol3;
+}
+
+.public-DraftStyleDefault-depth4.public-DraftStyleDefault-reset {
+  counter-reset: ol4;
+}

--- a/components/Explorer.module.css
+++ b/components/Explorer.module.css
@@ -55,6 +55,7 @@
 
 .outputText {
   white-space: pre-wrap;
+  word-break: break-word;
 }
 
 .outputOptions {

--- a/components/Explorer.tsx
+++ b/components/Explorer.tsx
@@ -266,8 +266,6 @@ const Explorer = ({
       prompt: editorState.getCurrentContent().getPlainText(),
       stop: encodedStop,
       temperature,
-      // logprobs: 5,
-      // echo: true
     };
 
     const url = `https://api.openai.com/v1/engines/${languageEngine}/completions`;
@@ -319,7 +317,6 @@ const Explorer = ({
   const copyShareLink = async () => {
     let sharedId = (initialRequest as CompletionRequest)?.sharedId;
     if (currentCompletionId !== initialRequest.id || !sharedId) {
-      // get shared completion from completion in databse
       try {
         sharedId = await shareCompletionFromSaved(currentCompletionId);
       } catch (err) {

--- a/components/HistoryDrawer.tsx
+++ b/components/HistoryDrawer.tsx
@@ -156,7 +156,7 @@ const HistoryDrawer = ({
     setCurrSharingId(doc.id!);
 
     const sharedCompletionRequest: SharedCompletionRequest = {
-      editorContent: doc.editorContent,
+      editorContent: doc.editorContent || null,
       output: doc.output,
       prompt: doc.prompt,
       settings: doc.settings,

--- a/components/HistoryDrawer.tsx
+++ b/components/HistoryDrawer.tsx
@@ -156,9 +156,9 @@ const HistoryDrawer = ({
     setCurrSharingId(doc.id!);
 
     const sharedCompletionRequest: SharedCompletionRequest = {
+      editorContent: doc.editorContent,
       output: doc.output,
       prompt: doc.prompt,
-      editorContent: doc.editorContent,
       settings: doc.settings,
     };
 

--- a/components/HistoryDrawer.tsx
+++ b/components/HistoryDrawer.tsx
@@ -158,6 +158,7 @@ const HistoryDrawer = ({
     const sharedCompletionRequest: SharedCompletionRequest = {
       output: doc.output,
       prompt: doc.prompt,
+      editorContent: doc.editorContent,
       settings: doc.settings,
     };
 

--- a/components/ProvenanceTextDisplay.module.css
+++ b/components/ProvenanceTextDisplay.module.css
@@ -1,0 +1,3 @@
+.human {
+  font-weight: bold;
+}

--- a/components/ProvenanceTextDisplay.tsx
+++ b/components/ProvenanceTextDisplay.tsx
@@ -1,0 +1,60 @@
+import { forEach, map } from "lodash";
+
+import styles from "./ProvenanceTextDisplay.module.css";
+
+interface Props {
+  content: any;
+}
+
+const ProvenanceTextDisplay = ({ content }: Props) => {
+  return (
+    <span>
+      {map(content.blocks, (block) => {
+        const { inlineStyleRanges, key, text } = block;
+
+        const styleMap = [];
+        let processedIdx = 0;
+
+        forEach(inlineStyleRanges, (range) => {
+          const { length, offset } = range;
+
+          if (processedIdx < offset) {
+            styleMap.push({
+              text: text.substring(processedIdx, offset),
+              provenance: "gpt3",
+            });
+          }
+
+          styleMap.push({
+            text: text.substring(offset, length + offset),
+            provenance: "human",
+          });
+
+          processedIdx = length + offset;
+        });
+
+        if (processedIdx < text.length) {
+          styleMap.push({
+            text: text.substring(processedIdx, text.length),
+            provenance: "gpt3",
+          });
+        }
+
+        return (
+          <p key={key}>
+            {map(styleMap, (section) => {
+              const { text, provenance } = section;
+              return (
+                <span className={`${provenance === "human" && styles.human}`}>
+                  {text}
+                </span>
+              );
+            })}
+          </p>
+        );
+      })}
+    </span>
+  );
+};
+
+export default ProvenanceTextDisplay;

--- a/components/ProvenanceTextInput.tsx
+++ b/components/ProvenanceTextInput.tsx
@@ -1,0 +1,107 @@
+import {
+  CharacterMetadata,
+  Editor,
+  EditorState,
+  getDefaultKeyBinding,
+} from "draft-js";
+import { OrderedSet } from "immutable";
+import { includes } from "lodash";
+
+import { KEY_ENTER } from "../lib/shortcuts";
+
+interface Props {
+  editorState: EditorState;
+  setEditorState: (editorState: EditorState) => void;
+  passedRef: any;
+}
+
+const ProvenanceTextInput = ({
+  editorState,
+  setEditorState,
+  passedRef,
+}: Props) => {
+  const createBoldStyle = () => {
+    return CharacterMetadata.create({ style: OrderedSet.of("BOLD") });
+  };
+
+  const handleChange = (e: EditorState) => {
+    const selection = e.getSelection();
+    const key = selection.getStartKey();
+    const offset = selection.getStartOffset();
+
+    if (
+      includes(
+        [
+          "insert-characters",
+          "backspace-character",
+          "delete-character",
+          "remove-range",
+        ],
+        e.getLastChangeType()
+      )
+    ) {
+      const content = e.getCurrentContent();
+      const blocks = content.getBlockMap();
+
+      let afterChangedBlock = false;
+      const updatedBlocks = blocks.map((block, blockKey) => {
+        if (afterChangedBlock) {
+          return block?.set(
+            "characterList",
+            block.getCharacterList().map(createBoldStyle)
+          );
+        } else if (blockKey === key) {
+          afterChangedBlock = true;
+          return block?.set(
+            "characterList",
+            block
+              .getCharacterList()
+              .map(
+                (
+                  style: CharacterMetadata | undefined,
+                  idx: number | undefined
+                ) => {
+                  return idx! < offset - 1 ? style : createBoldStyle();
+                }
+              )
+          );
+        } else {
+          return block;
+        }
+      });
+
+      const updatedContent = content.set("blockMap", updatedBlocks);
+
+      setEditorState(
+        EditorState.setInlineStyleOverride(
+          EditorState.create({
+            currentContent: updatedContent,
+            selection: selection,
+          }),
+          OrderedSet.of("BOLD")
+        )
+      );
+    } else {
+      setEditorState(e);
+    }
+  };
+
+  const handleKeyEvent = (e: any) => {
+    // Shift + Enter key events handled in Explorer component
+    if (e.keyCode == KEY_ENTER && e.shiftKey) {
+      return null;
+    }
+    return getDefaultKeyBinding(e);
+  };
+
+  return (
+    <Editor
+      editorState={editorState}
+      keyBindingFn={handleKeyEvent}
+      onChange={handleChange}
+      ref={passedRef}
+    />
+  );
+};
+
+export default ProvenanceTextInput;

--- a/components/ProvenanceTextInput.tsx
+++ b/components/ProvenanceTextInput.tsx
@@ -1,3 +1,4 @@
+// EXTERNAL IMPORTS
 import {
   CharacterMetadata,
   Editor,
@@ -7,18 +8,19 @@ import {
 import { OrderedSet } from "immutable";
 import { includes } from "lodash";
 
+// INTERNAL IMPORTS
 import { KEY_ENTER } from "../lib/shortcuts";
 
 interface Props {
+  passedRef: any;
   editorState: EditorState;
   setEditorState: (editorState: EditorState) => void;
-  passedRef: any;
 }
 
 const ProvenanceTextInput = ({
+  passedRef,
   editorState,
   setEditorState,
-  passedRef,
 }: Props) => {
   const createBoldStyle = () => {
     return CharacterMetadata.create({ style: OrderedSet.of("BOLD") });
@@ -41,16 +43,17 @@ const ProvenanceTextInput = ({
       )
     ) {
       const content = e.getCurrentContent();
-      const blocks = content.getBlockMap();
 
       let afterChangedBlock = false;
-      const updatedBlocks = blocks.map((block, blockKey) => {
+      const blocks = content.getBlockMap().map((block, blockKey) => {
         if (afterChangedBlock) {
           return block?.set(
             "characterList",
             block.getCharacterList().map(createBoldStyle)
           );
-        } else if (blockKey === key) {
+        }
+
+        if (blockKey === key) {
           afterChangedBlock = true;
           return block?.set(
             "characterList",
@@ -65,17 +68,15 @@ const ProvenanceTextInput = ({
                 }
               )
           );
-        } else {
-          return block;
         }
-      });
 
-      const updatedContent = content.set("blockMap", updatedBlocks);
+        return block;
+      });
 
       setEditorState(
         EditorState.setInlineStyleOverride(
           EditorState.create({
-            currentContent: updatedContent,
+            currentContent: content.set("blockMap", blocks),
             selection: selection,
           }),
           OrderedSet.of("BOLD")

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -22,6 +22,7 @@ export interface Annotations {
 
 export interface CompletionRequest {
   id?: string;
+  editorContent: any;
   createdAt: any;
   output: any;
   prompt: string;
@@ -36,10 +37,30 @@ export interface SharedCompletionRequest {
   id?: string;
   output: any;
   prompt: string;
+  editorContent: any;
   settings: GPTSettings;
 
   annotations?: Annotations;
 }
+
+export const shareCompletionFromSaved = async (savedId: string) => {
+  const savedCompletion = await db
+    .collection(COMPLETION_REQUESTS)
+    .doc(savedId)
+    .get();
+  if (!savedCompletion.exists) throw new Error("Can't find document");
+
+  const data = savedCompletion.data();
+
+  const sharedCompletionRequest: SharedCompletionRequest = {
+    editorContent: data?.editorContent,
+    output: data?.output,
+    prompt: data?.prompt,
+    settings: data?.settings,
+  };
+
+  return await shareCompletionRequest(savedId, sharedCompletionRequest);
+};
 
 export const shareCompletionRequest = async (
   id: string,

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -22,8 +22,8 @@ export interface Annotations {
 
 export interface CompletionRequest {
   id?: string;
-  editorContent: any;
   createdAt: any;
+  editorContent: any;
   output: any;
   prompt: string;
   settings: GPTSettings;
@@ -35,9 +35,9 @@ export interface CompletionRequest {
 
 export interface SharedCompletionRequest {
   id?: string;
+  editorContent: any;
   output: any;
   prompt: string;
-  editorContent: any;
   settings: GPTSettings;
 
   annotations?: Annotations;
@@ -51,6 +51,8 @@ export const shareCompletionFromSaved = async (savedId: string) => {
   if (!savedCompletion.exists) throw new Error("Can't find document");
 
   const data = savedCompletion.data();
+
+  if (data?.sharedId) return data.sharedId;
 
   const sharedCompletionRequest: SharedCompletionRequest = {
     editorContent: data?.editorContent,

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
   },
   "dependencies": {
     "copy-to-clipboard": "^3.3.1",
+    "draft-js": "^0.11.6",
     "firebase": "7.16.1",
+    "immutable": "3.8.2",
     "lodash": "^4.17.19",
     "moment": "^2.27.0",
     "next": "9.4.4",
@@ -22,6 +24,7 @@
     "semantic-ui-react": "^1.0.0"
   },
   "devDependencies": {
+    "@types/draft-js": "^0.10.43",
     "@types/lodash": "^4.14.158",
     "@types/node": "^14.0.24",
     "@types/react": "^16.9.43",
@@ -32,6 +35,9 @@
     "prettier": "2.0.5",
     "typescript": "^3.9.7",
     "yarn": "^1.22.4"
+  },
+  "resolutions": {
+    "draft-js/immutable": "3.8.2"
   },
   "husky": {
     "hooks": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -2,6 +2,7 @@ import { AppProps } from "next/app";
 import { Icon } from "semantic-ui-react";
 
 import "semantic-ui-css/semantic.min.css";
+import "../components/Draft.css";
 
 import Head from "next/head";
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -121,7 +121,7 @@ export function Home({ user, sharedRequest }: Props) {
 
   const populateRun = (recentRun: CompletionRequest) => {
     setMode(DEVELOP_MODE);
-    setInitialRequest(recentRun);
+    setInitialRequest({ ...recentRun });
   };
 
   const signOut = () => auth.signOut();

--- a/pages/p/[sharedId].tsx
+++ b/pages/p/[sharedId].tsx
@@ -21,6 +21,7 @@ import db, {
 } from "../../lib/db";
 import { getOutputText, nullDefault } from "../../lib/utils";
 import PrettyCode from "../../components/PrettyCode";
+import ProvenanceTextDisplay from "../../components/ProvenanceTextDisplay";
 
 import styles from "./shared.module.css";
 
@@ -33,7 +34,7 @@ interface Props {
 const Shared = ({ completion, sharedId }: Props) => {
   if (!completion) return <NextError statusCode={404} />;
 
-  const { prompt, output, settings } = completion;
+  const { editorContent, prompt, output, settings } = completion;
 
   const outputTextRef = useRef<HTMLSpanElement>(null);
   const [outputOffset, setOutputOffset] = useState(0);
@@ -84,11 +85,15 @@ const Shared = ({ completion, sharedId }: Props) => {
             className={styles.displayHeader}
             style={{ marginTop: `${outputOffset}px` }}
           >
-            <Label color="blue">Completion</Label>
+            <Label color="blue">Last completion</Label>
           </div>
         </div>
         <div className={styles.displaySection}>
-          <span>{prompt}</span>
+          {editorContent ? (
+            <ProvenanceTextDisplay content={editorContent} />
+          ) : (
+            <span>{prompt}</span>
+          )}
           <span className={styles.outputText} ref={outputTextRef}>
             <strong>{getOutputText(output)}</strong>
           </span>

--- a/pages/p/shared.module.css
+++ b/pages/p/shared.module.css
@@ -27,6 +27,7 @@
 
 .displayHeaders {
   padding-right: 10px;
+  white-space: nowrap;
 }
 
 .displayHeader {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1347,6 +1347,14 @@
   resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
   integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
 
+"@types/draft-js@^0.10.43":
+  version "0.10.43"
+  resolved "https://registry.yarnpkg.com/@types/draft-js/-/draft-js-0.10.43.tgz#6b1ed4b848ae0a169e3343b5923e013e3bfc29d0"
+  integrity sha512-vy6hVgA/6uZhqBCinYw4lGVsjL/GnqwYTl2zUC8lMAHanwK9/tcVVDApWPf2GFvU/Nd986nVbUXPHDbKMrdSug==
+  dependencies:
+    "@types/react" "*"
+    immutable "~3.7.4"
+
 "@types/json-schema@^7.0.4":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
@@ -1726,6 +1734,11 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+asap@~2.0.3:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
+  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -2422,6 +2435,11 @@ core-js@3.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.5.tgz#7395dc273af37fb2e50e9bd3d9fe841285231d1a"
   integrity sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==
 
+core-js@^2.4.1:
+  version "2.6.11"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.11.tgz#38831469f9922bded8ee21c9dc46985e0399308c"
+  integrity sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2854,6 +2872,15 @@ dot-prop@^5.2.0:
   dependencies:
     is-obj "^2.0.0"
 
+draft-js@^0.11.6:
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/draft-js/-/draft-js-0.11.6.tgz#a2b54c211674d10ed65a2234c2ddd12f824cc709"
+  integrity sha512-H8OaophZecxm0L/C0LvOo6IZrbMb+s0txPXF7DW3E2oUjSo5ufvWvWb3B/0K2wRqBnwJrRxApqljD899i0fZMA==
+  dependencies:
+    fbjs "^1.0.0"
+    immutable "~3.7.4"
+    object-assign "^4.1.1"
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
@@ -3136,6 +3163,25 @@ faye-websocket@0.11.3:
   integrity sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==
   dependencies:
     websocket-driver ">=0.5.1"
+
+fbjs-css-vars@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz#216551136ae02fe255932c3ec8775f18e2c078b8"
+  integrity sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ==
+
+fbjs@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-1.0.0.tgz#52c215e0883a3c86af2a7a776ed51525ae8e0a5a"
+  integrity sha512-MUgcMEJaFhCaF1QtWGnmq9ZDRAzECTCRAF7O6UZIlAlkTs1SasiX9aP0Iw7wfD2mJ7wDTNfg2w7u5fSCwJk1OA==
+  dependencies:
+    core-js "^2.4.1"
+    fbjs-css-vars "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.18"
 
 figgy-pudding@^3.5.1:
   version "3.5.2"
@@ -3560,6 +3606,16 @@ iferr@^0.1.5:
   resolved "https://registry.yarnpkg.com/iferr/-/iferr-0.1.5.tgz#c60eed69e6d8fdb6b3104a1fcbca1c192dc5b501"
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
+immutable@3.8.2:
+  version "3.8.2"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.8.2.tgz#c2439951455bb39913daf281376f1530e104adf3"
+  integrity sha1-wkOZUUVbs5kT2vKBN28VMOEErfM=
+
+immutable@~3.7.4:
+  version "3.7.6"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-3.7.6.tgz#13b4d3cb12befa15482a26fe1b2ebae640071e4b"
+  integrity sha1-E7TTyxK++hVIKib+Gy665kAHHks=
+
 import-fresh@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-2.0.0.tgz#d81355c15612d386c61f9ddd3922d4304822a546"
@@ -3881,7 +3937,7 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
-isomorphic-fetch@2.2.1:
+isomorphic-fetch@2.2.1, isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
   integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
@@ -5288,6 +5344,13 @@ promise-polyfill@8.1.3:
   resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.3.tgz#8c99b3cf53f3a91c68226ffde7bde81d7f904116"
   integrity sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==
 
+promise@^7.1.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
+  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
+  dependencies:
+    asap "~2.0.3"
+
 prop-types-exact@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/prop-types-exact/-/prop-types-exact-1.2.0.tgz#825d6be46094663848237e3925a98c6e944e9869"
@@ -5854,7 +5917,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4:
+setimmediate@^1.0.4, setimmediate@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -6442,6 +6505,11 @@ typescript@^3.9.7:
   version "3.9.7"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
   integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
+
+ua-parser-js@^0.7.18:
+  version "0.7.21"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
+  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
# In this PR
- Update prompt field to show different styling depending on whether it was human or GPT-3 generated
- Updating earlier text turns subsequent text bold (indicate human generated)
- Store editor state in Firebase
- Reload when past completion selected

- Fix bug where completions shared from output panel will have incorrect prompts - uses text inside prompt field rather than the input prompt for the completion (now pulls saved completion data from database)

## Follow up
- [x] Update share page to show provenance and not just most recent completion

Closes #1 